### PR TITLE
Return accumulated outputs of intermediate actions when running a script/action sequence

### DIFF
--- a/demos/dispatcher_demo.py
+++ b/demos/dispatcher_demo.py
@@ -51,6 +51,6 @@ fruit_script = [fruit_counter, count_adder, count_commentary]
 
 print("Run an input through a sequence of actions ...")
 input_text = "sally has 8 apples, six pomegranates, 4 bananas and 2 carrots"
-result = ad.execute(fruit_script, utterance=input_text)
+output, _ = ad.execute(fruit_script, utterance=input_text)
 
-print(result)
+print(output)

--- a/docs/tutorials/executing_actions.ipynb
+++ b/docs/tutorials/executing_actions.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -43,7 +43,7 @@
        "{'output': 'Canberra.'}"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -77,7 +77,7 @@
        "{'output': 'Canberra'}"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -125,7 +125,7 @@
        "{'output': 'Cairo.'}"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -158,7 +158,7 @@
        "{'summed_numbers': 33}"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -294,19 +294,17 @@
      "text": [
       "Dear valued customer,\n",
       "\n",
-      "Thank you for choosing Fruits'R'Us as your preferred fruit supplier. We appreciate your business and are glad to assist you.\n",
+      "Thank you for choosing Fruits'R'Us for your fruit needs. We appreciate your business.\n",
       "\n",
-      "We understand that you would like to purchase 12 fruits from us. Just to restate your order, you are requesting 12 fruits from our company.\n",
+      "I understand that you would like to purchase 12 fruits from us. To confirm, you are requesting 12 fruits in total, is that correct?\n",
       "\n",
-      "Please be advised that our company policy allows a maximum of 10 fruits per order to ensure the quality and freshness of our produce. However, we can certainly accommodate your request by splitting it into two separate orders if you would like.\n",
+      "Please note that our policy allows a maximum of 10 fruits per order. However, we would be happy to assist you in placing multiple orders if you require more than 10 fruits.\n",
       "\n",
-      "Alternatively, if you prefer to stick to the maximum of 10 fruits per order, we can assist you in selecting the fruits that you would like to purchase.\n",
-      "\n",
-      "Thank you once again for choosing Fruits'R'Us. We look forward to serving you again in the future.\n",
+      "Thank you for your understanding and please let us know how we can assist you further.\n",
       "\n",
       "Best regards,\n",
-      "[Your Name]\n",
-      "Fruits'R'Us Customer Service\n"
+      "\n",
+      "[Your name]\n"
      ]
     }
    ],
@@ -317,9 +315,9 @@
     "script = [enumerate_fruits, sum_fruits, create_reply]\n",
     "\n",
     "input_text = \"I'd like to order 4 bananas, 6 oranges, a cabbage and 2 honeycrips\"\n",
-    "output_dict = ad.execute(script, utterance=input_text)\n",
+    "output, _ = ad.execute(script, utterance=input_text)\n",
     "\n",
-    "print(output_dict['reply'])"
+    "print(output['reply'])"
    ]
   },
   {
@@ -359,18 +357,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'output': \" 'strawberries':2, 'bananas':4\"}"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'output': \" 'strawberries':2, 'bananas':4\"}\n"
+     ]
     }
    ],
    "source": [
@@ -379,7 +374,9 @@
     "ad = ActionDispatcher(dir='../../demos/ralf_data')\n",
     "\n",
     "enumerate_fruits = Action(prompt_name='enumerate_fruits')\n",
-    "ad.execute([enumerate_fruits], utterance='i have 2 strawberry shortcakes, 4 bananas and 6 hot dogs')\n"
+    "output, _ = ad.execute([enumerate_fruits], utterance='i have 2 strawberry shortcakes, 4 bananas and 6 hot dogs')\n",
+    "\n",
+    "print(output)"
    ]
   }
  ],
@@ -399,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.12"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/ralf/dispatcher.py
+++ b/ralf/dispatcher.py
@@ -1,7 +1,7 @@
 import os
 import yaml
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 
 import openai
 
@@ -284,13 +284,15 @@ class ActionDispatcher:
         
         return ru.DEFAULT_ACTION_MODEL | model_config
 
-    def _run_script(self, action_list: list[Action], **kwargs) -> dict:
+    def _run_script(self, action_list: list[Action], **kwargs) -> Tuple[dict, dict]:
         """Takes in a list of Action objects and runs them in sequence
 
         :param action_list: a list of actions to execute in sequence
         :type action_list: list[Action]
-        :return: the output dictionary of the last action in the sequence
-        :rtype: dict
+        :return: a tuple containing:
+                    - output dictionary of the last action in the sequence
+                    - dictionary with accumulated outputs of intermediate actions
+        :rtype: Tuple[dict, dict]
         """
         context = kwargs
         output = {}
@@ -300,7 +302,7 @@ class ActionDispatcher:
 
             context = context | output
 
-        return output
+        return output, context
 
     def _run_action(self, 
                     action: Action,


### PR DESCRIPTION
To ensure that we have access to the outputs of all actions executed in an action sequence, I modified the `_run_script` function in `dispatcher.py` to return a tuple. The first item in the tuple is the output dictionary of the last action in the script. The second item in the tuple is the accumulated dictionary of intermediate action outputs (but also includes the output of the last action, as this was easier and I don't see much downside to it). 